### PR TITLE
Fix JST/UTC timezone conversion bug in schedule display

### DIFF
--- a/app/api/schedules/route.ts
+++ b/app/api/schedules/route.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { checkIsParent, checkIsStaff, getCurrentUser } from "@/lib/session";
 import { scheduleSchema } from "@/lib/validations/schedule";
 import { z } from "zod";
+import { fromZonedTime } from "date-fns-tz";
 
 export async function POST(req: Request) {
   try {
@@ -11,6 +12,11 @@ export async function POST(req: Request) {
     }
 
     const body = await req.json();
+    
+    // Parse dates accounting for Japan Standard Time (JST)
+    // When frontend sends ISO strings, they represent UTC time
+    // but the user intended them to be JST, so we parse as-is 
+    // since the database stores in UTC
     const payload = scheduleSchema.parse({
       ...body,
       start: new Date(body.start),

--- a/components/schedules/schedule-create-form.tsx
+++ b/components/schedules/schedule-create-form.tsx
@@ -18,6 +18,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
 import { format, setHours, setMinutes } from "date-fns";
 import { ja } from "date-fns/locale";
+import { zonedTimeToUtc } from "date-fns-tz";
 import { cn } from "@/lib/utils";
 import { Icons } from "../icons";
 import { DevTool } from "@hookform/devtools";
@@ -62,6 +63,11 @@ export const ScheduleCreateForm = ({
 
   const onSubmit = async (data: ScheduleSchemaType) => {
     try {
+      // Convert JST dates to UTC properly to avoid timezone shift
+      const timeZone = "Asia/Tokyo";
+      const startUtc = zonedTimeToUtc(data.start, timeZone);
+      const endUtc = zonedTimeToUtc(data.end, timeZone);
+      
       const response = await fetch(`/api/schedules`, {
         method: "POST",
         headers: {
@@ -69,8 +75,8 @@ export const ScheduleCreateForm = ({
         },
         body: JSON.stringify({
           studentId: data.studentId,
-          start: data.start.toISOString(),
-          end: data.end.toISOString(),
+          start: startUtc.toISOString(),
+          end: endUtc.toISOString(),
           meal: data.meal,
           notes: data.notes,
         }),

--- a/components/schedules/schedule-multi-create-form.tsx
+++ b/components/schedules/schedule-multi-create-form.tsx
@@ -28,6 +28,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
 import { format, parse, setHours, setMinutes } from "date-fns";
 import { ja } from "date-fns/locale";
+import { zonedTimeToUtc } from "date-fns-tz";
 import { MealSetting } from "@prisma/client";
 import { cn } from "@/lib/utils";
 import { Icons } from "../icons";
@@ -67,12 +68,22 @@ export const ScheduleMultiCreateForm = ({
 
   const onSubmit = async (data: ScheduleMultiCreateSchemaType) => {
     try {
+      // Convert JST dates to UTC properly to avoid timezone shift
+      const timeZone = "Asia/Tokyo";
+      const dataWithUtcDates = {
+        ...data,
+        dates: data.dates.map(date => ({
+          start: zonedTimeToUtc(date.start, timeZone),
+          end: zonedTimeToUtc(date.end, timeZone),
+        })),
+      };
+      
       const response = await fetch(`/api/schedules/multi`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(data),
+        body: JSON.stringify(dataWithUtcDates),
       });
 
       if (!response.ok) {

--- a/components/schedules/schedule-multi-update-form.tsx
+++ b/components/schedules/schedule-multi-update-form.tsx
@@ -27,6 +27,7 @@ import { Button } from "../ui/button";
 import { Icons } from "../icons";
 import { useTime } from "./use-time";
 import { cn } from "@/lib/utils";
+import { zonedTimeToUtc } from "date-fns-tz";
 
 type Props = {
   schedules: Schedule[];
@@ -47,12 +48,19 @@ const ScheduleMultiUpdateForm = ({ schedules, onSuccess, onError }: Props) => {
 
   const onSubmit = async (data: ScheduleMultiUpdateSchemaType) => {
     try {
+      // Convert JST dates to UTC properly to avoid timezone shift
+      const timeZone = "Asia/Tokyo";
+      const dataWithUtcDate = {
+        ...data,
+        start: zonedTimeToUtc(data.start, timeZone),
+      };
+      
       const response = await fetch(`/api/schedules/multi`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(data),
+        body: JSON.stringify(dataWithUtcDate),
       });
 
       if (!response.ok) {

--- a/components/schedules/schedule-update-form.tsx
+++ b/components/schedules/schedule-update-form.tsx
@@ -28,6 +28,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
+import { zonedTimeToUtc } from "date-fns-tz";
 import { Schedule } from "@prisma/client";
 import { cn } from "@/lib/utils";
 import { Icons } from "../icons";
@@ -64,14 +65,19 @@ export const ScheduleUpdateForm = ({
 
   const onSubmit = async (data: ScheduleUpdateSchemaType) => {
     try {
+      // Convert JST dates to UTC properly to avoid timezone shift
+      const timeZone = "Asia/Tokyo";
+      const startUtc = zonedTimeToUtc(data.start, timeZone);
+      const endUtc = zonedTimeToUtc(data.end, timeZone);
+      
       const response = await fetch(`/api/schedules/${schedule.id}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          start: data.start.toISOString(),
-          end: data.end.toISOString(),
+          start: startUtc.toISOString(),
+          end: endUtc.toISOString(),
           meal: data.meal,
           notes: data.notes,
         }),


### PR DESCRIPTION
Fixes #36

## Summary
- Fixed timezone conversion bug causing schedule dates to shift by one day
- Parent view was showing holidays as registered and correct dates as unregistered
- Used `zonedTimeToUtc()` from `date-fns-tz` to properly convert JST dates to UTC

## Changes
- Fixed single schedule creation form
- Fixed multi-schedule creation form
- Fixed schedule update forms
- Added proper JST timezone handling throughout

🤖 Generated with [Claude Code](https://claude.ai/code)